### PR TITLE
Rename 2FA setup form phone input id

### DIFF
--- a/spec/features/create_account_spec.rb
+++ b/spec/features/create_account_spec.rb
@@ -15,7 +15,7 @@ describe 'create account' do
     fill_in 'password_form_password', with: PASSWORD
     submit_password
 
-    fill_in 'two_factor_setup_form_phone', with: PHONE
+    fill_in 'user_phone_form_phone', with: PHONE
     click_send_otp
 
     otp = check_for_otp

--- a/spec/features/sp_signup_spec.rb
+++ b/spec/features/sp_signup_spec.rb
@@ -23,7 +23,7 @@ describe 'SP initiated sign up' do
     fill_in 'password_form_password', with: PASSWORD
     submit_password
 
-    fill_in 'two_factor_setup_form_phone', with: PHONE
+    fill_in 'user_phone_form_phone', with: PHONE
     click_send_otp
 
     otp = check_for_otp

--- a/spec/support/idp_helpers.rb
+++ b/spec/support/idp_helpers.rb
@@ -27,7 +27,7 @@ module IdpHelpers
     visit confirmation_link
     fill_in 'password_form_password', with: PASSWORD
     submit_password
-    fill_in 'two_factor_setup_form_phone', with: PHONE
+    fill_in 'user_phone_form_phone', with: PHONE
     click_send_otp
     otp = check_for_otp
     fill_in 'code', with: otp


### PR DESCRIPTION
In the upcoming release, the phone form was renamed from
`two_factor_setup_from` to `user_phone_form`. This commit changes the
tests to reflect that.