### PR TITLE
Add SMS sign in script for NR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,10 @@ IDP_URL=https://user:pass@idp.dev.login.gov
 NR_TOTP_SIGN_IN_EMAIL='fabulouser-user@gmail.com'
 NR_TOTP_SIGN_IN_PASSWORD=sekreter-phrase
 NR_TOTP_SIGN_IN_TOTP_SECRET=1234567890
+
+NR_SMS_SIGN_IN_EMAIL='fabulosest-user@gmail.com'
+NR_SMS_SIGN_IN_PASSWORD=sekretest-phrase
+NR_SMS_SIGN_IN_TWILIO_PHONE=1234567890
+
+TWILIO_SID=twilio-secret-id
+TWILIO_TOKEN=twilio-secret-token

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,13 @@
 extends: airbnb-base
 rules:
+  comma-dangle:
+  - 0
+  - array: always
+    objects: always
+    imports: always
+    exports: always
+    functions: ignore
+  function-paren-newline: 0
   global-require: 0
   newline-per-chained-call: 0
   no-console: 0

--- a/new_relic_scripts/bootstrap.js
+++ b/new_relic_scripts/bootstrap.js
@@ -1,0 +1,9 @@
+// Initialize $browser and $driver if we are local and not on New Relic
+try {
+  // eslint-disable-next-line no-unused-expressions
+  $browser && $driver;
+} catch (error) {
+  global.$driver = require('selenium-webdriver');
+  global.$browser = new $driver.Builder().forBrowser('chrome').build();
+  require('dotenv').load();
+}

--- a/new_relic_scripts/sms_sign_in.js
+++ b/new_relic_scripts/sms_sign_in.js
@@ -1,0 +1,42 @@
+require('./bootstrap');
+
+const {
+  fillOutOTPForm,
+  fillOutSignInForm,
+  submitForm,
+  verifyCurrentPath,
+  visitURL,
+} = require('./support/browser');
+const { getOTPFromTwilio } = require('./support/twilio_helpers');
+
+const {
+  IDP_URL,
+  NR_SMS_SIGN_IN_EMAIL,
+  NR_SMS_SIGN_IN_PASSWORD,
+  NR_SMS_SIGN_IN_TWILIO_PHONE
+} = process.env;
+
+visitURL(IDP_URL).then(() =>
+  fillOutSignInForm({
+    email: NR_SMS_SIGN_IN_EMAIL,
+    password: NR_SMS_SIGN_IN_PASSWORD,
+  })
+).then(() =>
+  submitForm()
+).then(() =>
+  verifyCurrentPath('/login/two_factor/sms?reauthn=false')
+).then(() =>
+  getOTPFromTwilio({
+    phoneNumber: NR_SMS_SIGN_IN_TWILIO_PHONE,
+    // 30 second padding necessary for Twilio to return the message
+    sentAfter: new Date(Date.now() - 30000),
+  })
+).then(otp =>
+  fillOutOTPForm(otp)
+).then(() =>
+  submitForm()
+).then(() =>
+  verifyCurrentPath('/account')
+).then(() =>
+  console.log('Done!')
+);

--- a/new_relic_scripts/support/browser.js
+++ b/new_relic_scripts/support/browser.js
@@ -1,0 +1,54 @@
+const { expect } = require('chai');
+const url = require('url');
+
+const {
+  IDP_URL
+} = process.env;
+
+const fillOutOTPForm = (otp) => {
+  console.log('Entering OTP');
+  return $browser.findElement($driver.By.id('code')).sendKeys(otp);
+};
+
+const fillOutSignInForm = ({ email, password }) => {
+  console.log('Filling out email');
+  return $browser.findElement($driver.By.id('user_email')).sendKeys(email).then(() => {
+    console.log('Filling out password');
+    return $browser.findElement($driver.By.id('user_password')).sendKeys(password);
+  });
+};
+
+const idpUrl = (path) => {
+  const ipdUrl = url.parse(IDP_URL);
+  ipdUrl.auth = null;
+  return ipdUrl.resolve(path);
+};
+
+const submitForm = () => {
+  console.log('Clicking the submit button');
+  return $browser.findElement($driver.By.name('commit')).click();
+};
+
+const verifyCurrentPath = (expectedPath) => {
+  const expectedUrl = idpUrl(expectedPath);
+  console.log(`Verifying that current url equals ${expectedUrl}`);
+
+  return $browser.sleep(1000).then(() =>
+    $browser.getCurrentUrl()
+  ).then((currentUrl) => {
+    expect(currentUrl).to.eq(expectedUrl);
+  });
+};
+
+const visitURL = (targetUrl) => {
+  console.log(`Visiting ${targetUrl}`);
+  return $browser.get(targetUrl);
+};
+
+module.exports = {
+  fillOutOTPForm,
+  fillOutSignInForm,
+  submitForm,
+  verifyCurrentPath,
+  visitURL,
+};

--- a/new_relic_scripts/support/twilio_helpers.js
+++ b/new_relic_scripts/support/twilio_helpers.js
@@ -1,0 +1,73 @@
+const Q = require('q');
+const querystring = require('querystring');
+const request = require('request');
+
+const {
+  TWILIO_SID,
+  TWILIO_TOKEN,
+} = process.env;
+const MAX_OTP_FETCH_ATTEMPTS = 5;
+
+const TWILIO_MESSAGES_URL = [
+  'https://api.twilio.com/2010-04-01/Accounts',
+  TWILIO_SID,
+  'Messages.json'
+].join('/');
+
+const getTextMessages = ({ sentAfter, phoneNumber }) => {
+  const deferred = Q.defer();
+  const requestURL = [
+    TWILIO_MESSAGES_URL,
+    querystring.stringify({ 'DateSent>': sentAfter.toISOString(), To: phoneNumber }),
+  ].join('?');
+  request.get(requestURL, {
+    auth: { username: TWILIO_SID, password: TWILIO_TOKEN },
+  }, (error, response, body) => {
+    if (error) {
+      deferred.reject(error);
+    } else if (response.statusCode !== 200) {
+      deferred.reject(
+        new Error(`Unexpected Twilio Status: ${response.statusCode}`)
+      );
+    } else {
+      deferred.resolve(JSON.parse(body).messages);
+    }
+  });
+  return deferred.promise;
+};
+
+const readOTPFromMessage = (message) => {
+  const match = message.body.match(/(\d+) is your login\.gov one-time/);
+  if (match) {
+    return match[1];
+  }
+  return null;
+};
+
+const getOTPFromTwilio = ({ sentAfter, phoneNumber, attempts = 0 }) => {
+  console.log(`Fetching OTP from Twilio, attempt ${attempts + 1}/${MAX_OTP_FETCH_ATTEMPTS}`);
+  if (attempts >= MAX_OTP_FETCH_ATTEMPTS) {
+    throw new Error('Unable to fetch OTP from Twilio');
+  }
+  return getTextMessages({
+    sentAfter,
+    phoneNumber,
+  }).then(messages => messages.reduce((currentOTP, message) => {
+    const otp = readOTPFromMessage(message);
+    if (otp) {
+      return otp;
+    }
+    return currentOTP;
+  }, null)).then((otp) => {
+    if (otp) {
+      return otp;
+    }
+    return $broswer.sleep(2000).then(() =>
+      getOTPFromTwilio({ sentAfter, phoneNumber, attempts: attempts + 1 })
+    );
+  });
+};
+
+module.exports = {
+  getOTPFromTwilio,
+};

--- a/new_relic_scripts/totp_sign_in.js
+++ b/new_relic_scripts/totp_sign_in.js
@@ -1,7 +1,14 @@
+require('./bootstrap');
+
 const base32 = require('thirty-two');
-const { expect } = require('chai');
 const notp = require('notp');
-const url = require('url');
+const {
+  fillOutOTPForm,
+  fillOutSignInForm,
+  submitForm,
+  verifyCurrentPath,
+  visitURL,
+} = require('./support/browser');
 
 const {
   IDP_URL,
@@ -10,52 +17,26 @@ const {
   NR_TOTP_SIGN_IN_TOTP_SECRET,
 } = process.env;
 
-// Initialize $browser and $driver if we are local and not on New Relic
-try {
-  // eslint-disable-next-line no-unused-expressions
-  $browser && $driver;
-} catch (error) {
-  $driver = require('selenium-webdriver');
-  $browser = new $driver.Builder().forBrowser('chrome').build();
-}
-
 const generateTOTP = () => {
   const decodedTOTPSecret = base32.decode(NR_TOTP_SIGN_IN_TOTP_SECRET);
   return notp.totp.gen(decodedTOTPSecret);
 };
 
-const idpURL = (path) => {
-  const ipdUrl = url.parse(IDP_URL);
-  ipdUrl.auth = null;
-  return ipdUrl.resolve(path);
-};
-
-$browser.get(IDP_URL).then(() => {
-  console.log('Filling out email');
-  return $browser.findElement($driver.By.id('user_email')).sendKeys(NR_TOTP_SIGN_IN_EMAIL);
-}).then(() => {
-  console.log('Filling out password');
-  return $browser.findElement($driver.By.id('user_password')).sendKeys(NR_TOTP_SIGN_IN_PASSWORD);
-}).then(() => {
-  console.log('Clicking the submit button');
-  return $browser.findElement($driver.By.name('commit')).click();
-}).then(() => {
-  console.log('Verifying that URL is 2FA URL');
-  return $browser.getCurrentUrl();
-}).then((currentUrl) => {
-  // Current URL should be authenticator 2FA
-  expect(currentUrl).to.eq(idpURL('/login/two_factor/authenticator'));
-
-  // Fill in TOTP field with TOTP
-  console.log('Entering TOTP');
-  return $browser.findElement($driver.By.id('code')).sendKeys(generateTOTP());
-}).then(() => {
-  console.log('Clicking the submit button');
-  return $browser.findElement($driver.By.name('commit')).click();
-}).then(() => {
-  console.log('Verifying that URL is account URL');
-  return $browser.getCurrentUrl();
-}).then((currentUrl) => {
-  expect(currentUrl).to.eq(idpURL('/account'));
-  console.log('Done!');
-});
+visitURL(IDP_URL).then(() =>
+  fillOutSignInForm({
+    email: NR_TOTP_SIGN_IN_EMAIL,
+    password: NR_TOTP_SIGN_IN_PASSWORD,
+  })
+).then(() =>
+  submitForm()
+).then(() =>
+  verifyCurrentPath('/login/two_factor/authenticator')
+).then(() =>
+  fillOutOTPForm(generateTOTP())
+).then(() =>
+  submitForm()
+).then(() =>
+  verifyCurrentPath('/account')
+).then(() =>
+  console.log('Done!')
+);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "eslint-config-airbnb-base": "^12.0.0",
     "eslint-plugin-import": "^2.7.0",
     "notp": "^2.0.3",
+    "q": "^1.5.0",
+    "request": "^2.82.0",
     "selenium-webdriver": "^3.5.0",
     "thirty-two": "^1.0.2",
     "webpack": "^3.5.6"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require('dotenv').load();
 
 const path = require('path');
 const webpack = require('webpack');
@@ -6,9 +6,14 @@ const webpack = require('webpack');
 // Whitelist specific env variables for use in DefinePlugin below
 const environmentVariables = [
   'IDP_URL',
+  'NR_SMS_SIGN_IN_EMAIL',
+  'NR_SMS_SIGN_IN_PASSWORD',
+  'NR_SMS_SIGN_IN_TWILIO_PHONE',
   'NR_TOTP_SIGN_IN_EMAIL',
   'NR_TOTP_SIGN_IN_PASSWORD',
   'NR_TOTP_SIGN_IN_TOTP_SECRET',
+  'TWILIO_SID',
+  'TWILIO_TOKEN',
 ].reduce((variables, key) => {
   const name = `process.env.${key}`;
   return Object.assign(variables, { [name]: JSON.stringify(process.env[key]) });
@@ -17,6 +22,15 @@ const environmentVariables = [
 module.exports = {
   entry: {
     totp_sign_in: './new_relic_scripts/totp_sign_in.js',
+    sms_sign_in: './new_relic_scripts/sms_sign_in.js',
+  },
+  externals: {
+    chai: 'commonjs chai',
+    crypto: 'commonjs crypto',
+    q: 'commonjs q',
+    querystring: 'commonjs querystring',
+    request: 'commonjs request',
+    url: 'commonjs url',
   },
   output: {
     path: path.resolve(__dirname, 'new_relic_scripts_out'),
@@ -36,8 +50,8 @@ module.exports = {
     ],
   },
   plugins: [
-    new webpack.IgnorePlugin(/selenium-webdriver/),
+    new webpack.IgnorePlugin(/selenium-webdriver|dotenv/),
     new webpack.DefinePlugin(environmentVariables),
-    new webpack.optimize.UglifyJsPlugin(),
   ],
+  target: 'node',
 };


### PR DESCRIPTION
**Why**: We want to use NR browser scripts to monitor SMS sign in to
make sure we are notified when users with SMS 2FA are unable to sign in

Also of note in the commit are significant changes to the webpack config:

- Change target to `node` so that browser shims aren't include
- Use commonjs requires for node modules available through New Relic
- Stop uglifying the code while bundling