### PR TITLE
Add script that, with high concurrency, reproduced CSRF issue

### DIFF
--- a/spec/features/create_account_spec.rb
+++ b/spec/features/create_account_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'create account' do
+  before { inbox_clear }
+
   it 'creates new account directly' do
     visit idp_signup_url
     email_address = random_email_address

--- a/spec/features/csrf_error_spec.rb
+++ b/spec/features/csrf_error_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'CSRF errors' do
+  it 'does not show any errors' do
+    visit idp_reset_password_url
+
+    expect(page).to have_content('Forgot')
+
+    fill_in 'password_reset_email_form_email', with: 'fake-email@login.gov'
+
+    page.driver.browser.remove_cookie 'AWSALB'
+
+    click_on 'Continue'
+
+    expect(page).to_not have_content('Oops')
+  end
+end

--- a/spec/features/reset_password_spec.rb
+++ b/spec/features/reset_password_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'password reset' do
+  before { inbox_clear }
+
   it 'resets password at LOA1' do
     creds = create_new_account
 

--- a/spec/features/sign_in_out_spec.rb
+++ b/spec/features/sign_in_out_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'sign in and out' do
+  before { inbox_clear }
+
   it 'creates account, signs out, signs back in' do
     creds = create_new_account
 

--- a/spec/features/sp_signup_spec.rb
+++ b/spec/features/sp_signup_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'SP initiated sign up' do
+  before { inbox_clear }
+
   it 'creates new account via SP' do
     page.driver.basic_authorize(basic_auth_user, basic_auth_pass)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,10 +25,6 @@ RSpec.configure do |config|
 
   config.include GmailHelpers
   config.include IdpHelpers
-
-  config.before(:each) do
-    inbox_clear
-  end
 end
 
 Dotenv.load


### PR DESCRIPTION
Example for how to run this:

```
yes spec/features/csrf_error_spec.rb | head -n 10 | parallel -j 5 "bundle exec rspec {} | grep FAILED"
```

This runs the spec with 10 times total with 5 job runners concurrently, and it shows 5 failure for me consistently in a lower environment