### PR TITLE
Check for email at end of SP sign up

### DIFF
--- a/spec/features/sp_signup_spec.rb
+++ b/spec/features/sp_signup_spec.rb
@@ -44,5 +44,6 @@ describe 'SP initiated sign up' do
     click_on 'Continue'
 
     expect(current_url).to match(%r{https://sp})
+    expect(page).to have_content(email_address)
   end
 end


### PR DESCRIPTION
**Why**: To check that the sign in to the SP was successful, and not
just that the user was redirected to the SP.