### PR TITLE
Update nokogiri to 1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,9 +24,9 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
+    mini_portile2 (2.3.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     oauth (0.5.1)
     poltergeist (1.14.0)
       capybara (~> 2.1)
@@ -67,7 +67,7 @@ DEPENDENCIES
   rspec
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.3.5p376
 
 BUNDLED WITH
-   1.14.6
+   1.16.0


### PR DESCRIPTION
**Why**: Version 1.7.1 had a buffer overflow related security issue