### PR TITLE
Update specs and README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,14 @@
 EMAIL=some-fabulous-user@gmail.com
 EMAIL_PASSWORD=sekrit-phrase
 PHONE=5555555555
+
+# INT
 SP_URL=https://sp-oidc-sinatra.int.identitysandbox.gov
 IDP_URL=https://idp.int.identitysandbox.gov
+
+# STAGING
+#SP_URL=https://login.uat.usajobs.gov/Access/Transition
+#IDP_URL=https://idp.staging.login.gov
 
 NR_TOTP_SIGN_IN_EMAIL='fabulouser-user@gmail.com'
 NR_TOTP_SIGN_IN_PASSWORD=sekreter-phrase

--- a/README.md
+++ b/README.md
@@ -9,11 +9,39 @@ Automated tests for Login.gov
 To test Login.gov
 -----------------
 
-Create a new Google email and voice account. Don't use your primary Google email
-account because the tests will clear your inbox! The Google voice account is
-important because the tests assume that the text message that was sent to the
-phone will be forwarded to your email. Verify that "Forward messages to email"
-is turned on in your [Google Voice settings](https://voice.google.com/settings).
+We have a dummy Google email and voice account used for running these smoke
+tests. The credentials are in a `.env` file that you can fetch using the
+instructions in the Release Management Wiki. If for some reason, the dummy
+account no longer works, you can create your own Google email and voice account.
+Don't use your primary Google email account because the tests will clear your
+inbox! If you end up using your own account, follow the instructions below.
+Otherwise, skip to [Run the tests](#run-the-tests).
+
+Google Voice Settings
+---------------------
+Make sure the following are enabled in your [Google Voice settings](https://voice.google.com/settings):
+
+### Phone numbers
+- Add a linked number
+- Turn on "Do not disturb"
+
+### Messages
+- Turn on "Forward messages to email"
+
+### Calls
+- Check "Forward calls to linked numbers"
+
+### Voicemail
+- Turn on "Get voicemail via email"
+- Turn on "Let Google analyze voicemail transcripts"
+
+Note that if your Google account uses 2FA, you will need to create an
+[App password](https://myaccount.google.com/apppasswords) and use that as the
+value of `EMAIL_PASSWORD`. To create the app password, Choose "Mail" from the
+"Select app" dropdown and "Other" from "Select device".
+
+ENV Vars
+--------
 
 Create a `.env` file with the Google credentials and phone number:
 
@@ -22,37 +50,34 @@ $ cp .env.example .env
 $ vi .env
 ```
 
-Note that if your Google account uses 2FA, you will need to create an
-[App password](https://myaccount.google.com/apppasswords) and use that as the
-value of `EMAIL_PASSWORD`. To create the app password, Choose "Mail" from the
-"Select app" dropdown and "Other" from "Select device".
-
 Make sure that `TWILIO_SID` and `TWILIO_TOKEN` correspond to the Figaro config
 values `twilio_sid` and `twilio_auth_token` in the environment that are you
 are currently testing (based on `IDP_URL`).
 
-Install dependencies:
+Run the tests
+-------------
 
 ```bash
 $ bundle install
 ```
 
-Run the tests:
-
 ```bash
 $ make test
 ```
 
-Note about Voice OTP testing
-----------------------------
+### Testing `int` and `staging`
+By default, the tests use the `int` server. To run the smoke tests
+against staging, using USAJOBS as the SP, comment out `SP_URL` and `IDP_URL`
+in the `INT` section of your `.env`, and uncomment `SP_URL` and `IDP_URL` in
+the `STAGING` section.
+
+### Note about Voice OTP testing
 Google Voice transcription is not very accurate with the passcodes. We've tried
 to account for the most common scenarios, but it's possible the code won't be
 correctly transcribed. If a Voice OTP spec fails, try running it again.
 
 To create scripts for New Relic monitoring
 ------------------------------------------
-
-To create scripts for New Relic monitoring:
 
 - Run `npm install` to install dependencies
 - Run `make build_nr_scripts` to write the scripts to new_relic_scripts_out
@@ -71,7 +96,7 @@ set according to the instructions below.
 
 ### TOTP Sign in
 
-Create a test user on Login.gov. Setup TOTP for the user an save the TOTP code.
+Create a test user on Login.gov. Setup TOTP for the user and save the TOTP code.
 Afterwards, add the following to your `.env`:
 
 - `IDP_URL`: The IDP url to run the script against

--- a/spec/features/sp_signin_spec.rb
+++ b/spec/features/sp_signin_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
 
-describe 'SP initiated sign up' do
+describe 'SP initiated sign in' do
   before { inbox_clear }
 
-  it 'creates new account via SP' do
+  it 'redirects back to SP' do
+    visit idp_signup_url
+    creds = create_new_account_with_sms
+    visit idp_logout_url
+
     visit sp_url
     if sp_url == usa_jobs_url
       click_button 'Continue'
@@ -11,13 +15,15 @@ describe 'SP initiated sign up' do
       find(:css, '.btn').click
     end
 
-    expect(current_url).to match(%r{https://idp})
+    click_on 'Sign in'
 
-    click_on 'Create an account'
-    create_new_account_with_sms
+    fill_in 'user_email', with: creds[:email_address]
+    fill_in 'user_password', with: PASSWORD
+    click_on 'Next'
 
-    expect(current_path).to eq '/sign_up/completed'
-
+    otp = check_for_otp(option: 'sms')
+    fill_in 'code', with: otp
+    click_on 'Submit'
     click_on 'Continue'
 
     if sp_url == usa_jobs_url

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ require 'gmail'
 require 'capybara/rspec'
 require 'selenium/webdriver'
 
-
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w[headless disable-gpu] }
@@ -36,6 +35,7 @@ RSpec.configure do |config|
 
   config.include GmailHelpers
   config.include IdpHelpers
+  config.include SpHelpers
 end
 
 Dotenv.load

--- a/spec/support/gmail_helpers.rb
+++ b/spec/support/gmail_helpers.rb
@@ -19,7 +19,7 @@ module GmailHelpers
     inbox_unread.each do |email|
       msg = email.message.parts[0].body
       if option == 'sms'
-        otp = msg.match(/(\d+) is your login.gov one-time/)[1]
+        otp = msg.match(/(\d+) is your login.gov/)[1]
       elsif option == 'voice'
         otp = msg.match(/passcode is (\d+\s?\d+)\s?(one|to|for|hate)?/)
         if otp[2]

--- a/spec/support/sp_helpers.rb
+++ b/spec/support/sp_helpers.rb
@@ -1,0 +1,5 @@
+module SpHelpers
+  def usa_jobs_url
+    'https://login.uat.usajobs.gov/Access/Transition'
+  end
+end


### PR DESCRIPTION
**Why**: The wording for the SMS message has changed, but the tests
were still relying on the message being the same for both authentication
and confirmation.

- Update README with Google Voice settings instructions
- Add staging ENV vars and update tests to make it easy to test with
USAJOBS in staging