### PR TITLE
Fill in nickname field during TOTP setup

### DIFF
--- a/spec/support/idp_helpers.rb
+++ b/spec/support/idp_helpers.rb
@@ -29,6 +29,9 @@ module IdpHelpers
     find("label[for='two_factor_options_form_selection_auth_app']").click
     click_on 'Continue'
     secret = find('#qr-code').text
+    # We can remove the `if page.find('#name')` on the next line once the code
+    # for supporting multiple TOTP apps is deployed all the way to prod
+    fill_in 'name', with: 'Authentication app' if page.find('#name')
     fill_in 'code', with: generate_totp_code(secret)
     click_button 'Submit'
     click_on 'Continue'


### PR DESCRIPTION
**Why**: So that the create account flow w/ TOTP can be done successfully.