### PR TITLE
hotfix for multiple saml sign in buttons

### DIFF
--- a/spec/support/sp_helpers.rb
+++ b/spec/support/sp_helpers.rb
@@ -23,14 +23,14 @@ module SpHelpers
 
   def visit_idp_from_saml_sp
     visit saml_sp_url
-    find(:css, '.sign-in-bttn').click
+    first(:css, '.sign-in-bttn').click
 
     expect(current_url).to match(%r{https://(idp|secure)\..*\.gov})
   end
 
   def visit_idp_from_saml_sp_with_ial2
     visit saml_sp_url + '?ial=2'
-    find(:css, '.sign-in-bttn').click
+    first(:css, '.sign-in-bttn').click
 
     expect(current_url).to match(%r{https://(idp|secure)\..*\.gov})
   end


### PR DESCRIPTION
We added a second sign-in button that does a POST some time ago, but now the smoke tests are failing on it.  This should just grab the first button (GET).