### PR TITLE
HOTFIX: using the SAML Sinatra SP, not Rails

### DIFF
--- a/spec/features/create_account_spec.rb
+++ b/spec/features/create_account_spec.rb
@@ -84,8 +84,8 @@ describe 'create account' do
 
     click_on 'Continue'
 
-    expect(page).to have_content('SAML Rails Example')
+    expect(page).to have_content('SAML Sinatra Example')
     expect(page).to have_content(email_address)
-    expect(current_url).to match(%r{https://sp})
+    expect(current_url).to match(%r{#{saml_sp_url}})
   end
 end

--- a/spec/features/sp_signin_spec.rb
+++ b/spec/features/sp_signin_spec.rb
@@ -27,9 +27,9 @@ describe 'SP initiated sign in' do
       creds = { email_address: EMAIL }
       sign_in_and_2fa(creds)
 
-      expect(page).to have_content('SAML Rails Example')
+      expect(page).to have_content('SAML Sinatra Example')
       expect(page).to have_content(EMAIL)
-      expect(current_url).to match(%r{https://sp})
+      expect(current_url).to match(%r{#{saml_sp_url}})
 
       log_out_from_saml_sp
     end


### PR DESCRIPTION
We have a few tests failing looking for "SAML Rails Example" when we are now using the SAML Sinatra SP.