### PR TITLE
Use new OIDC SP regex on sign in

### DIFF
--- a/spec/features/sp_signin_spec.rb
+++ b/spec/features/sp_signin_spec.rb
@@ -14,7 +14,7 @@ describe 'SP initiated sign in' do
         expect(current_url).to match(%r{https://.*usajobs\.gov})
       else
         expect(page).to have_content('OpenID Connect Sinatra Example')
-        expect(current_url).to match(%r{https://sp-oidc-sinatra})
+        expect(current_url).to match(%r{https:\/\/(sp|\w+-identity)\-oidc\-sinatra})
       end
 
       log_out_from_oidc_sp


### PR DESCRIPTION
**Why**: We fixed all of the create account tests with this new regex, but didn't apply it to the sign in one so that is failing now.