### PR TITLE
Only click on the agree and continue link if it is present

### DIFF
--- a/spec/features/create_account_spec.rb
+++ b/spec/features/create_account_spec.rb
@@ -68,7 +68,11 @@ describe 'create account' do
   def expect_user_is_redirected_to_oidc_sp
     expect(page).to have_current_path('/sign_up/completed')
 
-    click_on 'Accept and continue'
+    if page.has_link?('Agree and continue')
+      click_on 'Agree and continue'
+    elsif page.has_link?('Accept and continue')
+      click_on 'Accept and continue'
+    end
 
     if oidc_sp_is_usajobs?
       expect(page).to have_content('Welcome ')
@@ -82,10 +86,14 @@ describe 'create account' do
   def expect_user_is_redirected_to_saml_sp
     expect(page).to have_current_path('/sign_up/completed')
 
-    click_on 'Accept and continue'
+    if page.has_link?('Agree and continue')
+      click_on 'Agree and continue'
+    elsif page.has_link?('Accept and continue')
+      click_on 'Accept and continue'
+    end
 
     expect(page).to have_content('SAML Sinatra Example')
     expect(page).to have_content(email_address)
-    expect(current_url).to match(%r{#{saml_sp_url}})
+    expect(current_url).to match(/#{saml_sp_url}/)
   end
 end


### PR DESCRIPTION
**Why**: Now that a user's consent can expire our smoke tests users' consent is expiring causing them to see the consent screen again. This commit clicks the button if it is present.

Also, we changed the name of the button after rolling out new code. This means there are 2 possible button texts to look for. This commit looks for both.