### PR TITLE
Look for correct button title

### DIFF
--- a/spec/features/create_account_spec.rb
+++ b/spec/features/create_account_spec.rb
@@ -68,11 +68,7 @@ describe 'create account' do
   def expect_user_is_redirected_to_oidc_sp
     expect(page).to have_current_path('/sign_up/completed')
 
-    if page.has_link?('Agree and continue')
-      click_on 'Agree and continue'
-    elsif page.has_link?('Accept and continue')
-      click_on 'Accept and continue'
-    end
+    click_on 'Agree and continue'
 
     if oidc_sp_is_usajobs?
       expect(page).to have_content('Welcome ')
@@ -86,11 +82,7 @@ describe 'create account' do
   def expect_user_is_redirected_to_saml_sp
     expect(page).to have_current_path('/sign_up/completed')
 
-    if page.has_link?('Agree and continue')
-      click_on 'Agree and continue'
-    elsif page.has_link?('Accept and continue')
-      click_on 'Accept and continue'
-    end
+    click_on 'Agree and continue'
 
     expect(page).to have_content('SAML Sinatra Example')
     expect(page).to have_content(email_address)


### PR DESCRIPTION
Ok so in #70 I added the wrong copy.... and #71 has the right stuff

This cleans that up a tad

There's only "Agree and continue" copy in the app:
https://github.com/18f/identity-idp/commit/c206f4dfc04953ce6bbe114e90f9f0cd06ecde43#diff-c282f912903bc51173b9399ec1802b24R4

```
identity-idp:master> git grep "Accept and continue" | wc -l
       0
identity-idp:master> git grep "Agree and continue" | wc -l
       1
```
