### PR TITLE
Refactor to run one workflow per-environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,31 @@
-version: 2
-jobs:
-  test:
+---
+version: 2.1
+
+executors:
+  # Common container definition used by all jobs
+  ruby_browsers:
     docker:
       - image: circleci/ruby:2.5.5-browsers
+
+commands:
+  # Smoke test command template
+  smoketest:
+    parameters:
+      env:
+        type: string
     steps:
       - checkout
       - run:
           name: Setup bundler
           command: gem install bundler
-      - restore-cache:
+      - restore_cache:
           keys:
             - v2-identity-monitor-bundle-{{ checksum "Gemfile.lock" }}
       - run:
           name: Install dependencies
           command: |
             bundle install --path vendor/bundle
-      - save-cache:
+      - save_cache:
           key: v2-identity-monitor-bundle-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
@@ -23,17 +33,82 @@ jobs:
           name: Setup tests
           command: bin/circleci-setup
       - run:
-          name: Run tests
-          command: bin/circleci-run
+          name: Run smoketest suite against environment
+          command: bin/circleci-run << parameters.env >>
+
+jobs:
+  smoketest_dev:
+    executor: ruby_browsers
+    steps:
+      - smoketest:
+          env: dev
+
+  smoketest_int:
+    executor: ruby_browsers
+    steps:
+      - smoketest:
+          env: int
+
+  smoketest_staging:
+    executor: ruby_browsers
+    steps:
+      - smoketest:
+          env: staging
+
+  smoketest_prod:
+    executor: ruby_browsers
+    steps:
+      - smoketest:
+          env: prod
+
 workflows:
-   version: 2
-   hourly:
-     triggers:
-       - schedule:
-           cron: "0 * * * *"
-           filters:
-             branches:
-               only:
-                 - master
-     jobs:
-       - test
+  # DEV - Not yet ready
+  # smoketest_dev:
+  #   triggers:
+  #     - schedule:
+  #         cron: "15 * * * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #   jobs:
+  #     - prepare
+  #     - smoketest_dev:
+  #       requires:
+  #         - prepare
+
+  # INT
+  smoketest_int:
+    triggers:
+      - schedule:
+          cron: "20 * * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - smoketest_int
+
+  # STAGING
+  smoketest_staging:
+    triggers:
+      - schedule:
+          cron: "25 * * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - smoketest_staging
+
+  # PROD
+  smoketest_prod:
+    triggers:
+      - schedule:
+          cron: "30 * * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - smoketest_prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
   # smoketest_dev:
   #   triggers:
   #     - schedule:
-  #         cron: "15 * * * *"
+  #         cron: "20 * * * *"
   #         filters:
   #           branches:
   #             only:
@@ -81,7 +81,7 @@ workflows:
   smoketest_int:
     triggers:
       - schedule:
-          cron: "20 * * * *"
+          cron: "30 * * * *"
           filters:
             branches:
               only:
@@ -93,7 +93,7 @@ workflows:
   smoketest_staging:
     triggers:
       - schedule:
-          cron: "25 * * * *"
+          cron: "40 * * * *"
           filters:
             branches:
               only:
@@ -105,7 +105,7 @@ workflows:
   smoketest_prod:
     triggers:
       - schedule:
-          cron: "30 * * * *"
+          cron: "50 * * * *"
           filters:
             branches:
               only:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@
 # https://github.com/bbatsov/rubocop/blob/master/config/disabled.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   UseCache: true
   Exclude:
     - 'Gemfile'

--- a/bin/circleci-run
+++ b/bin/circleci-run
@@ -3,12 +3,17 @@
 require 'optparse'
 
 def run_and_retry_tests(environment, retries)
-  extra_flags = ''
+  cmd = ['HEADLESS_BROWSER=true', "LOWER_ENV=#{environment}", 'bundle', 'exec',
+         'rspec']
+  retry_flags = ['--only-failure']
+
   retries.times do
-    return if system "HEADLESS_BROWSER=true LOWER_ENV=#{environment} bundle exec rspec#{extra_flags}"
+    return if system cmd.join(' ')
 
     puts "Smoke tests failed in #{environment}. Retrying..."
-    extra_flags = ' --only-failure'
+
+    # Retries use '--only-failure' to skip over previous sucessful tests
+    retry_flags.empty? or cmd << retry_flags.shift
   end
   raise "Tests failed in #{environment}"
 end
@@ -29,7 +34,8 @@ def main
 
     USAGEDOC
 
-    opts.on('-r NUM', Integer, 'Times to retry test.  (Default: 3)') do |r|
+    opts.on('-r', '--retry-count NUM', Integer,
+            'Times to retry test.  (Default: 3)') do |r|
       retries = r
     end
   end

--- a/bin/circleci-run
+++ b/bin/circleci-run
@@ -1,25 +1,52 @@
 #!/usr/bin/env ruby
 
-##
-# There are lots of moving parts so the tests can be flaky.
-# For better or worse we only sound the alarm if we fail after 3 tries.
-#
-def run_and_retry_tests(environment)
-  result = system "HEADLESS_BROWSER=true LOWER_ENV=#{environment} bundle exec rspec"
-  return if result
+require 'optparse'
 
-  2.times do
+def run_and_retry_tests(environment, retries)
+  extra_flags = ''
+  retries.times do
+    return if system "HEADLESS_BROWSER=true LOWER_ENV=#{environment} bundle exec rspec#{extra_flags}"
+
     puts "Smoke tests failed in #{environment}. Retrying..."
-    return if system "HEADLESS_BROWSER=true LOWER_ENV=#{environment} bundle exec rspec --only-failure"
+    extra_flags = ' --only-failure'
   end
   raise "Tests failed in #{environment}"
 end
 
-puts 'Running tests in INT'
-run_and_retry_tests('int')
+def main
+  basename = File.basename($PROGRAM_NAME)
+  retries = 3
 
-puts 'Running tests in STAGING'
-run_and_retry_tests('staging')
+  optparse = OptionParser.new do |opts|
+    opts.banner = <<~USAGEDOC
+      usage: #{basename} [-r NUM] ENVIRONMENT
 
-puts 'Renning tests in PROD'
-run_and_retry_tests('prod')
+      Run smoke tests for a given environment.  (Intended for pipeline use.)
+
+      Args:
+          ENVIRONMENT Target to test.  Sets "LOWER_ENV" in the rspec test.
+                      Environment variables for the target must be present.
+
+    USAGEDOC
+
+    opts.on('-r NUM', Integer, 'Times to retry test.  (Default: 3)') do |r|
+      retries = r
+    end
+  end
+
+  args = optparse.parse!
+
+  if args.length != 1
+    warn optparse
+    exit 1
+  end
+
+  env = ARGV[0]
+
+  puts "Running tests in #{env}"
+  run_and_retry_tests(env, retries)
+end
+
+if __FILE__ == $PROGRAM_NAME
+  main
+end


### PR DESCRIPTION
## Why
1) Allow for easy identification of which environment smoke test failed.
2) Allow manual running of smoke tests for a single environment, alleviating
     the need to run from local workstations.

## Changes
* Modify circleci-run to take a single environment name as an argument
  instead of hard coding all environments and running in serial.
* Add -r NUM option to control the number of retries for a smoke test
  run.  (Previous default of 3 maintained.)
* Refactor CircleCI definition:
  - Reusable executor definition to allow changing Ruby image in one place
  - Per-environment job definitions
  - Per-environment workflows triggered automatically (*:20 - int,
    *:25 - staging, *:30 - prod)

## Testing
* Edit `.circleci/config.yaml` and add your test branch name to one or more of the branch lists under the workflow trigger(s) you wish to test.  Example:  Run `int` scheduled test on branch `tester/thing`:
~~~
smoketest_int:
    triggers:
      - schedule:
          cron: "20 * * * *"
          filters:
            branches:
              only:
                - master
                - tester/thing
~~~
* Push the test branch and wait for the schedule to trigger
* Delete the branch after testing

## Additional

* See https://app.circleci.com/pipelines/github/18F/identity-monitor/1474/workflows/c8cf557e-3b75-4de1-b706-24d8bcaf1168 for a completed run
* Sample failure Slack message: https://gsa-tts.slack.com/archives/C0NGESUN5/p1588896756326100
* `bin/circleci-run` may also be useful for workstation test runs as it includes retry logic
