### PR TITLE
Click "Agree and Continue" on sign in if consent has expired

### DIFF
--- a/spec/features/sp_signin_spec.rb
+++ b/spec/features/sp_signin_spec.rb
@@ -8,6 +8,8 @@ describe 'SP initiated sign in' do
       visit_idp_from_oidc_sp
       creds = { email_address: EMAIL }
       sign_in_and_2fa(creds)
+      # If consent has expired, we need to click "Agree and continue"
+      click_on 'Agree and continue' if page.has_button?('Agree and continue')
 
       if oidc_sp_is_usajobs?
         expect(page).to have_content('Welcome ')
@@ -26,6 +28,9 @@ describe 'SP initiated sign in' do
       visit_idp_from_saml_sp
       creds = { email_address: EMAIL }
       sign_in_and_2fa(creds)
+
+      # If consent has expired, we need to click "Agree and continue"
+      click_on 'Agree and continue' if page.has_button?('Agree and continue')
 
       expect(page).to have_content('SAML Sinatra Example')
       expect(page).to have_content(EMAIL)


### PR DESCRIPTION
**Why**: If it has been > 1 year since a user consented to share their information the consent screen shows up. The user must click "Agree and Continue" to proceed. Consent expired on our smoke test user. The smoke tests were not expecting this so they did not click the button and expected to be at the SP.